### PR TITLE
perf: (DSO-2234) Set werf development mode as an optional flag

### DIFF
--- a/cmd/werf/utils.go
+++ b/cmd/werf/utils.go
@@ -22,7 +22,6 @@ func GenerateEnvFile(options Options) {
 		environment,
 		"--values",
 		fmt.Sprintf(".helm/values/%s.yaml", environment),
-		"--parallel",
 	}
 
 	if options.Secrets {

--- a/cmd/werf/utils.go
+++ b/cmd/werf/utils.go
@@ -22,7 +22,7 @@ func GenerateEnvFile(options Options) {
 		environment,
 		"--values",
 		fmt.Sprintf(".helm/values/%s.yaml", environment),
-		"--dev",
+		"--parallel",
 	}
 
 	if options.Secrets {
@@ -30,6 +30,13 @@ func GenerateEnvFile(options Options) {
 			werfCommand,
 			"--secret-values",
 			fmt.Sprintf(".helm/secrets/%s.yaml", environment),
+		)
+	}
+
+	if options.Development {
+		werfCommand = append(
+			werfCommand,
+			"--dev",
 		)
 	}
 
@@ -42,7 +49,7 @@ func GenerateEnvFile(options Options) {
 					file,
 				)
 			} else {
-				log.Fatalf("File doesn't exist")
+				log.Fatalf("File %s doesn't exist", file)
 			}
 		}
 	}
@@ -72,7 +79,7 @@ func GenerateEnvFile(options Options) {
 
 	renderedManifests := stdout.Bytes()
 
-	log.Printf("Obtaining env vars from rendered manifests...")
+	log.Infof("Obtaining env vars from rendered manifests...")
 
 	var manifests []parser.YamlDoc
 	decoder := yaml.NewDecoder(strings.NewReader(string(renderedManifests)))

--- a/cmd/werf/werf.go
+++ b/cmd/werf/werf.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Options struct {
+	Development bool
 	Environment string
 	Secrets     bool
 	Values      string
@@ -25,6 +26,7 @@ var Command = &cobra.Command{
 }
 
 func parseCommandFlags(cmd *cobra.Command) Options {
+	development, _ := cmd.Flags().GetBool("development")
 	environment, _ := cmd.Flags().GetString("environment")
 	secrets, _ := cmd.Flags().GetBool("secrets")
 	values, _ := cmd.Flags().GetString("extra-value")
@@ -32,6 +34,7 @@ func parseCommandFlags(cmd *cobra.Command) Options {
 	path, _ := cmd.Flags().GetStringArray("path")
 
 	return Options{
+		Development: development,
 		Environment: environment,
 		Secrets:     secrets,
 		Values:      values,
@@ -41,6 +44,12 @@ func parseCommandFlags(cmd *cobra.Command) Options {
 }
 
 func init() {
+	Command.Flags().BoolP(
+		"development",
+		"d",
+		false,
+		"Enable development mode for werf render command",
+	)
 	Command.Flags().String(
 		"extra-value",
 		"",


### PR DESCRIPTION
## Summary

- Set werf `--dev` flag as optional to improve performance
- Enhance werf sub-command logging

- Test

![image](https://github.com/user-attachments/assets/2028e997-c8a3-4f19-bd8f-92e02113f4b8)
![image](https://github.com/user-attachments/assets/88f21afe-deb2-46fb-8147-b599b44af0df)

